### PR TITLE
Sync life cycle calls

### DIFF
--- a/Example/Source/Controllers/HorizontalController/HorizontalController.swift
+++ b/Example/Source/Controllers/HorizontalController/HorizontalController.swift
@@ -36,6 +36,7 @@ class HorizontalController {
     
     private lazy var changePositionAction: ((Int) -> ())? = { [weak self] position in
         guard let strongSelf = self else { return }
+        self?.slideController.shift(pageIndex: 3, animated: false)
         switch position {
         case 0:
             strongSelf.slideController.titleView.position = TitleViewPosition.beside

--- a/Example/Source/Controllers/PageContent/PageLifeCycleObject.swift
+++ b/Example/Source/Controllers/PageContent/PageLifeCycleObject.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SlideController
 
-class PageLifeCycleObject : Initializable {
+class PageLifeCycleObject: Initializable {
     private var controller = ColorController()
     
     // MARK: - InitialazableImplementation
@@ -20,39 +20,26 @@ class PageLifeCycleObject : Initializable {
 }
 
 private typealias SlidePageLifeCycleImplementation = PageLifeCycleObject
-extension SlidePageLifeCycleImplementation : SlidePageLifeCycle {
+extension SlidePageLifeCycleImplementation: SlidePageLifeCycle {
     var isKeyboardResponsive: Bool {
         return false
     }
     
-    func didAppear() {
-        print(#function)
-        sleep(1)
-    }
+    func didAppear() { }
     
-    func didDissapear() {
-        print(#function)
-    }
+    func didDissapear() { }
     
-    func viewDidLoad() {
-        print(#function)
-    }
+    func viewDidLoad() { }
     
-    func viewDidUnload() {
-        print(#function)
-    }
+    func viewDidUnload() { }
     
-    func didStartSliding() {
-        print(#function)
-    }
+    func didStartSliding() { }
     
-    func didCancelSliding() {
-        print(#function)
-    }
+    func didCancelSliding() { }
 }
 
 private typealias ViewableImplementation = PageLifeCycleObject
-extension ViewableImplementation : Viewable {
+extension ViewableImplementation: Viewable {
     var view: UIView {
         get {
             return controller.view

--- a/Example/Source/Controllers/PageContent/PageLifeCycleObject.swift
+++ b/Example/Source/Controllers/PageContent/PageLifeCycleObject.swift
@@ -25,17 +25,30 @@ extension SlidePageLifeCycleImplementation : SlidePageLifeCycle {
         return false
     }
     
-    func didAppear() { }
+    func didAppear() {
+        print(#function)
+        sleep(1)
+    }
     
-    func didDissapear() { }
+    func didDissapear() {
+        print(#function)
+    }
     
-    func viewDidLoad() { }
+    func viewDidLoad() {
+        print(#function)
+    }
     
-    func viewDidUnload() { }
+    func viewDidUnload() {
+        print(#function)
+    }
     
-    func didStartSliding() { }
+    func didStartSliding() {
+        print(#function)
+    }
     
-    func didCancelSliding() { }
+    func didCancelSliding() {
+        print(#function)
+    }
 }
 
 private typealias ViewableImplementation = PageLifeCycleObject

--- a/Source/SlideContentController.swift
+++ b/Source/SlideContentController.swift
@@ -113,10 +113,10 @@ final class SlideContentController {
             /// Disable scrollView delegate so we won't get scrollViewDidScroll calls
             /// when transition through multiple pages is finished
             let delegate = strongSelf.slideContentView.delegate
-//            strongSelf.slideContentView.delegate = nil
+            strongSelf.slideContentView.delegate = nil
             strongSelf.slideContentView.showContainers(at: viewIndices)
             strongSelf.slideContentView.setContentOffset(endOffsetPoint, animated: false)
-//            strongSelf.slideContentView.delegate = delegate
+            strongSelf.slideContentView.delegate = delegate
         }
         if animated {
             return afterAnimation

--- a/Source/SlideContentController.swift
+++ b/Source/SlideContentController.swift
@@ -110,10 +110,13 @@ final class SlideContentController {
             guard let strongSelf = self else {
                 return
             }
-            DispatchQueue.main.async {
-                strongSelf.slideContentView.showContainers(at: viewIndices)
-                strongSelf.slideContentView.setContentOffset(endOffsetPoint, animated: false)
-            }
+            /// Disable scrollView delegate so we won't get scrollViewDidScroll calls
+            /// when transition through multiple pages is finished
+            let delegate = strongSelf.slideContentView.delegate
+//            strongSelf.slideContentView.delegate = nil
+            strongSelf.slideContentView.showContainers(at: viewIndices)
+            strongSelf.slideContentView.setContentOffset(endOffsetPoint, animated: false)
+//            strongSelf.slideContentView.delegate = delegate
         }
         if animated {
             return afterAnimation

--- a/Source/SlideController.swift
+++ b/Source/SlideController.swift
@@ -341,27 +341,21 @@ public class SlideController<T, N>: NSObject, UIScrollViewDelegate, ControllerSl
         guard pageIndex != currentIndex else {
             return
         }
-        if animated {
-            isForcedToSlide = true
-        }
+        isForcedToSlide = animated
         loadViewIfNeeded(pageIndex: pageIndex)
         
         sourceIndex = currentIndex
         destinationIndex = pageIndex
-        if animated {
-            if content.indices.contains(currentIndex) {
-                content[currentIndex].lifeCycleObject.didStartSliding()
-                scrollInProgress = true
-            }
-        } else {
-            updateCurrentIndex(pageIndex: pageIndex)
+        
+        scrollInProgress = true
+        if animated && content.indices.contains(currentIndex) {
+            content[currentIndex].lifeCycleObject.didStartSliding()
         }
         
-        if !self.contentSlidableController.slideContentView.isLayouted {
+        if !contentSlidableController.slideContentView.isLayouted {
             loadViewIfNeeded(pageIndex: pageIndex)
             updateCurrentIndex(pageIndex: pageIndex)
         } else {
-            
             scrollToPage(pageIndex: pageIndex, animated: animated)
         }
     }

--- a/Source/SlideController.swift
+++ b/Source/SlideController.swift
@@ -95,7 +95,7 @@ public class SlideController<T, N>: NSObject, UIScrollViewDelegate, ControllerSl
     private var destinationIndex: Int? = nil
     
     private var lastContentOffset: CGFloat = 0
-    private var didFinishForceSlide: (() -> ())?
+    private var didFinishForceSlide: (() -> Void)?
     private var didFinishSlideAction: (() -> Void)?
     private var isForcedToSlide = false
     private var isOnScreen = false
@@ -439,7 +439,6 @@ public class SlideController<T, N>: NSObject, UIScrollViewDelegate, ControllerSl
         scrollInProgress = false
         
         let nextIndex = destinationIndex ?? pageIndex(for: scrollView.contentOffset)
-        
         loadView(pageIndex: nextIndex)
         if nextIndex != currentIndex {
             if !isForcedToSlide {
@@ -490,7 +489,7 @@ private extension PrivateSlideController {
                 contentPageSize = containerView.frame.width
             }
         } else {
-            if titleViewPosition == TitleViewPosition.beside &&  titleViewAlignment == TitleViewAlignment.top {
+            if titleViewPosition == TitleViewPosition.beside && titleViewAlignment == TitleViewAlignment.top {
                 contentPageSize = containerView.frame.height - titleSlidableController.titleView.titleSize
             } else {
                 contentPageSize = containerView.frame.height
@@ -499,7 +498,7 @@ private extension PrivateSlideController {
         return contentPageSize
     }
     
-    private func scrollToPage(pageIndex: Int, animated: Bool) {
+    func scrollToPage(pageIndex: Int, animated: Bool) {
         titleSlidableController.jump(index: pageIndex, animated: animated)
         didFinishSlideAction = contentSlidableController.scroll(fromPage: currentIndex, toPage: pageIndex, animated: animated)
         if slideDirection == SlideDirection.horizontal {


### PR DESCRIPTION
__Fix for https://github.com/touchlane/SlideController/issues/44__
__Related to https://github.com/touchlane/SlideController/issues/36__
Added common callback for sliding end animation via user slide or shift.
So there is no need in checking if content has reached the page's edge.
With that the ```didAppear``` life cycle will be called slightly after animation ends.