### PR TITLE
fixed title item selection after insert action

### DIFF
--- a/Source/SlideController.swift
+++ b/Source/SlideController.swift
@@ -367,6 +367,9 @@ public class SlideController<T, N>: NSObject, UIScrollViewDelegate, ControllerSl
         } else {
             scrollToPage(pageIndex: pageIndex, animated: animated)
         }
+        if !animated {
+            scrollInProgress = false
+        }
     }
     
     public func showNext(animated: Bool = true) {


### PR DESCRIPTION
Reset ```scrollInProgress``` after ```shift``` without animation so that a title view is selectable.